### PR TITLE
Add TLS configuration support

### DIFF
--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
@@ -37,11 +37,11 @@ public final class OTLPGRPCMetricExporter: OTelMetricExporter {
             group: group,
             requestLogger: requestLogger,
             backgroundActivityLogger: backgroundActivityLogger,
-            trustRoots: .default
+            trustRoots: configuration.trustRoots
         )
     }
 
-    init(
+    public init(
         configuration: OTLPGRPCMetricExporterConfiguration,
         group: any EventLoopGroup,
         requestLogger: Logger,

--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporterConfiguration.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporterConfiguration.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOHPACK
+import NIOSSL
 import OTel
 
 /// Configuration for an ``OTLPGRPCMetricExporter``.
@@ -20,6 +21,7 @@ import OTel
 public struct OTLPGRPCMetricExporterConfiguration: Sendable {
     let endpoint: OTLPGRPCEndpoint
     let headers: HPACKHeaders
+    let trustRoots: NIOSSLTrustRoots
 
     /// Create a configuration for an ``OTLPGRPCMetricExporter``.
     ///
@@ -68,5 +70,17 @@ public struct OTLPGRPCMetricExporterConfiguration: Sendable {
                 return HPACKHeaders(keyValuePairs)
             }
         ) ?? [:]
+
+        let certificatePath = try environment.value(
+            programmaticOverride: nil as String?,
+            signalSpecificKey: "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE",
+            sharedKey: "OTEL_EXPORTER_OTLP_CERTIFICATE",
+            transformValue: { $0 }
+        )
+        if let certificatePath {
+            self.trustRoots = .file(certificatePath)
+        } else {
+            self.trustRoots = .default
+        }
     }
 }

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
@@ -46,11 +46,11 @@ public final class OTLPGRPCSpanExporter: OTelSpanExporter {
             group: group,
             requestLogger: requestLogger,
             backgroundActivityLogger: backgroundActivityLogger,
-            trustRoots: .default
+            trustRoots: configuration.trustRoots
         )
     }
 
-    init(
+    public init(
         configuration: OTLPGRPCSpanExporterConfiguration,
         group: any EventLoopGroup,
         requestLogger: Logger,

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporterConfiguration.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporterConfiguration.swift
@@ -12,12 +12,14 @@
 //===----------------------------------------------------------------------===//
 
 import NIOHPACK
+import NIOSSL
 import OTel
 
 /// Configuration of an ``OTLPGRPCSpanExporter``.
 public struct OTLPGRPCSpanExporterConfiguration: Sendable {
     let endpoint: OTLPGRPCEndpoint
     let headers: HPACKHeaders
+    let trustRoots: NIOSSLTrustRoots
 
     /// Create a configuration for an ``OTLPGRPCSpanExporter``.
     ///
@@ -66,5 +68,17 @@ public struct OTLPGRPCSpanExporterConfiguration: Sendable {
                 return HPACKHeaders(keyValuePairs)
             }
         ) ?? [:]
+
+        let certificatePath = try environment.value(
+            programmaticOverride: nil as String?,
+            signalSpecificKey: "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+            sharedKey: "OTEL_EXPORTER_OTLP_CERTIFICATE",
+            transformValue: { $0 }
+        )
+        if let certificatePath {
+            self.trustRoots = .file(certificatePath)
+        } else {
+            self.trustRoots = .default
+        }
     }
 }

--- a/Tests/OTLPGRPCTests/Metrics/OTLPGRPCMetricExporterConfigurationTests.swift
+++ b/Tests/OTLPGRPCTests/Metrics/OTLPGRPCMetricExporterConfigurationTests.swift
@@ -228,4 +228,22 @@ final class OTLPGRPCMetricExporterConfigurationTests: XCTestCase {
 
         XCTAssertEqual(configuration.headers, ["test": "42"])
     }
+
+    // MARK: - certificate
+
+    func test_init_certificate_specificEnvironment() throws {
+        let configuration = try OTLPGRPCMetricExporterConfiguration(
+            environment: ["OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE": "/tmp/cert.pem"]
+        )
+
+        XCTAssertEqual(configuration.trustRoots, .file("/tmp/cert.pem"))
+    }
+
+    func test_init_certificate_commonEnvironment() throws {
+        let configuration = try OTLPGRPCMetricExporterConfiguration(
+            environment: ["OTEL_EXPORTER_OTLP_CERTIFICATE": "/tmp/common.pem"]
+        )
+
+        XCTAssertEqual(configuration.trustRoots, .file("/tmp/common.pem"))
+    }
 }

--- a/Tests/OTLPGRPCTests/Tracing/OTLPGRPCSpanExporterConfigurationTests.swift
+++ b/Tests/OTLPGRPCTests/Tracing/OTLPGRPCSpanExporterConfigurationTests.swift
@@ -232,4 +232,22 @@ final class OTLPGRPCSpanExporterConfigurationTests: XCTestCase {
 
         XCTAssertEqual(configuration.headers, ["test": "42"])
     }
+
+    // MARK: - certificate
+
+    func test_init_certificate_specificEnvironment() throws {
+        let configuration = try OTLPGRPCSpanExporterConfiguration(
+            environment: ["OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE": "/tmp/cert.pem"]
+        )
+
+        XCTAssertEqual(configuration.trustRoots, .file("/tmp/cert.pem"))
+    }
+
+    func test_init_certificate_commonEnvironment() throws {
+        let configuration = try OTLPGRPCSpanExporterConfiguration(
+            environment: ["OTEL_EXPORTER_OTLP_CERTIFICATE": "/tmp/common.pem"]
+        )
+
+        XCTAssertEqual(configuration.trustRoots, .file("/tmp/common.pem"))
+    }
 }


### PR DESCRIPTION
## Summary
- allow specifying trust roots via `OTLPGRPC*ExporterConfiguration`
- expose public initializer that accepts `NIOSSLTrustRoots`
- add certificate environment variable parsing
- test TLS certificate configuration

## Testing
- `swift build` *(fails: couldn't fetch dependencies)*
- `swift test` *(fails: couldn't fetch dependencies)*